### PR TITLE
Move addressable dependency from Gemfile to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'addressable'
 # Specify your gem's dependencies in cex.io.gemspec
 gemspec

--- a/cexio.gemspec
+++ b/cexio.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-expectations"
   spec.add_development_dependency "rr"
   
+  spec.add_dependency "addressable"
 
 end


### PR DESCRIPTION
Without this change, an application requiring the `cexio` gem must also explicitly require `addressable` in it's own `Gemfile`. With this change, `addressable` is correctly inherited as a dependency when another application requires `cexio`.

Thanks!
