### PR TITLE
Fix multiple API calls within one second

### DIFF
--- a/lib/cexio.rb
+++ b/lib/cexio.rb
@@ -67,7 +67,7 @@ class API
 
 
   def nonce
-    self.nonce_v = Time.now.to_i.to_s
+    self.nonce_v = (Time.now.to_f * 1000000).to_i.to_s
   end
 
   def signature


### PR DESCRIPTION
The nonce is set to Time.now.to_i.to_s which results in multiple calls within the same second returning the error "Nonce must be incremented". Suggest setting nonce to microseconds since epoch to allow for more frequent calls.
